### PR TITLE
Rename old style constructor to __construct

### DIFF
--- a/MailUpExample/MailUpClient.php
+++ b/MailUpExample/MailUpClient.php
@@ -112,7 +112,7 @@
             $this->refreshToken = $inRefreshToken;
         }
         
-        function MailUpClient($inClientId, $inClientSecret, $inCallbackUri) {
+        function __construct($inClientId, $inClientSecret, $inCallbackUri) {
             $this->logonEndpoint = "https://services.mailup.com/Authorization/OAuth/LogOn";
             $this->authorizationEndpoint = "https://services.mailup.com/Authorization/OAuth/Authorization";
             $this->tokenEndpoint = "https://services.mailup.com/Authorization/OAuth/Token";


### PR DESCRIPTION
PHP 7 has deprecated old-style constructors (methods named like the class they belong to).
Since PHP 5 `__construct` should be used.

See [PHP's manual page about old-style constructors](http://www.php.net/manual/en/language.oop5.decon.php).
